### PR TITLE
Mono support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: csharp
 solution: src/GitTools.Core.sln
-sudo: true
+sudo: false
 install:
-  - sudo nuget update -self
+  # - sudo nuget update -self
   - nuget restore src/GitTools.Core.sln
   - nuget install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - nuget install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
 script:
   - xbuild ./src/GitTools.Core.sln /property:Configuration="Debug" /verbosity:detailed
-  - mono --debug --runtime=v4.0.30319 ./src/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./src/GitTools.Core.Tests/bin/Debug/GitTools.Core.Tests.Tests.dll
+  - mono --debug --runtime=v4.0.30319 ./src/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./output/debug/GitTools.Core.Tests/net45/GitTools.Core.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+solution: src/GitTools.Core.sln
+sudo: false
+install:
+  - nuget update -self
+  - nuget restore src/GitTools.Core.sln
+  - nuget install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
+script:
+  - xbuild ./src/GitTools.Core.sln /property:Configuration="Debug" /verbosity:detailed
+  - mono --debug --runtime=v4.0.30319 ./src/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./src/GitTools.Core.Tests/bin/Debug/GitTools.Core.Tests.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: csharp
 solution: src/GitTools.Core.sln
-sudo: false
+sudo: true
 install:
-  - nuget update -self
+  - sudo nuget update -self
   - nuget restore src/GitTools.Core.sln
   - nuget install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
 script:

--- a/src/GitTools.Core.Tests/Git/GitRepositoryFactoryTests.cs
+++ b/src/GitTools.Core.Tests/Git/GitRepositoryFactoryTests.cs
@@ -52,7 +52,7 @@
                         dynamicRepositoryPath = gitRepository.DotGitDirectory;
 
                         gitRepository.IsDynamic.ShouldBe(true);
-                        gitRepository.DotGitDirectory.ShouldBe(expectedDynamicRepoLocation + Path.DirectorySeparatorChar + ".git");
+                        gitRepository.DotGitDirectory.ShouldBe(Path.Combine(expectedDynamicRepoLocation, ".git"));
 
                         var currentBranch = gitRepository.Repository.Head.CanonicalName;
 
@@ -145,7 +145,7 @@
                     using (var gitRepository = GitRepositoryFactory.CreateRepository(repositoryInfo))
                     {
                         gitRepository.IsDynamic.ShouldBe(true);
-                        gitRepository.DotGitDirectory.ShouldBe(expectedDynamicRepoLocation + "_1" + Path.DirectorySeparatorChar + ".git");
+                        gitRepository.DotGitDirectory.ShouldBe(Path.Combine(expectedDynamicRepoLocation + "_1", ".git"));
                     }
                 }
             }

--- a/src/GitTools.Core.Tests/Git/GitRepositoryFactoryTests.cs
+++ b/src/GitTools.Core.Tests/Git/GitRepositoryFactoryTests.cs
@@ -31,7 +31,7 @@
             {
                 using (var fixture = new EmptyRepositoryFixture())
                 {
-                    var expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split('\\').Last());
+                    var expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split(Path.DirectorySeparatorChar).Last());
 
                     fixture.Repository.MakeCommits(5);
                     fixture.Repository.CreateFileAndCommit("TestFile.txt");
@@ -52,7 +52,7 @@
                         dynamicRepositoryPath = gitRepository.DotGitDirectory;
 
                         gitRepository.IsDynamic.ShouldBe(true);
-                        gitRepository.DotGitDirectory.ShouldBe(expectedDynamicRepoLocation + "\\.git");
+                        gitRepository.DotGitDirectory.ShouldBe(expectedDynamicRepoLocation + Path.DirectorySeparatorChar + ".git");
 
                         var currentBranch = gitRepository.Repository.Head.CanonicalName;
 
@@ -133,7 +133,7 @@
                 {
                     fixture.Repository.CreateFileAndCommit("TestFile.txt");
                     File.Copy(Path.Combine(fixture.RepositoryPath, "TestFile.txt"), Path.Combine(tempDir, "TestFile.txt"));
-                    expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split('\\').Last());
+                    expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split(Path.DirectorySeparatorChar).Last());
                     Directory.CreateDirectory(expectedDynamicRepoLocation);
 
                     var repositoryInfo = new RepositoryInfo
@@ -145,7 +145,7 @@
                     using (var gitRepository = GitRepositoryFactory.CreateRepository(repositoryInfo))
                     {
                         gitRepository.IsDynamic.ShouldBe(true);
-                        gitRepository.DotGitDirectory.ShouldBe(expectedDynamicRepoLocation + "_1\\.git");
+                        gitRepository.DotGitDirectory.ShouldBe(expectedDynamicRepoLocation + "_1" + Path.DirectorySeparatorChar + ".git");
                     }
                 }
             }

--- a/src/GitTools.Core.Tests/Git/GitRepositoryFactoryTests.cs
+++ b/src/GitTools.Core.Tests/Git/GitRepositoryFactoryTests.cs
@@ -151,10 +151,10 @@
             }
             finally
             {
-                Directory.Delete(tempDir, true);
+                DeleteHelper.DeleteDirectory(tempDir, true);
                 if (expectedDynamicRepoLocation != null)
                 {
-                    Directory.Delete(expectedDynamicRepoLocation, true);
+                    DeleteHelper.DeleteDirectory(expectedDynamicRepoLocation, true);
                 }
 
                 if (expectedDynamicRepoLocation != null)

--- a/src/GitTools.Core.Tests/Git/GitRepositoryHelperTests.cs
+++ b/src/GitTools.Core.Tests/Git/GitRepositoryHelperTests.cs
@@ -87,7 +87,7 @@
                     // Advance remote
                     fixture.Repository.Checkout("develop");
                     var advancedCommit = fixture.Repository.MakeACommit();
-                    localFixture.Repository.Network.Fetch(localFixture.Repository.Network.Remotes["origin"]);
+                    Commands.Fetch((Repository)localFixture.Repository, localFixture.Repository.Network.Remotes["origin"].Name, null, null, null);
                     localFixture.Repository.Checkout(advancedCommit.Sha);
                     localFixture.Repository.DumpGraph();
                     GitRepositoryHelper.NormalizeGitDirectory(localFixture.RepositoryPath, new AuthenticationInfo(), noFetch: false, currentBranch: "ref/heads/develop");

--- a/src/GitTools.Core.Tests/Git/GitRepositoryHelperTests.cs
+++ b/src/GitTools.Core.Tests/Git/GitRepositoryHelperTests.cs
@@ -87,7 +87,7 @@
                     // Advance remote
                     fixture.Repository.Checkout("develop");
                     var advancedCommit = fixture.Repository.MakeACommit();
-                    Commands.Fetch((Repository)localFixture.Repository, localFixture.Repository.Network.Remotes["origin"].Name, null, null, null);
+                    Commands.Fetch((Repository)localFixture.Repository, localFixture.Repository.Network.Remotes["origin"].Name, new string[0], null, null);
                     localFixture.Repository.Checkout(advancedCommit.Sha);
                     localFixture.Repository.DumpGraph();
                     GitRepositoryHelper.NormalizeGitDirectory(localFixture.RepositoryPath, new AuthenticationInfo(), noFetch: false, currentBranch: "ref/heads/develop");

--- a/src/GitTools.Core.Tests/GitRepositoryTests.cs
+++ b/src/GitTools.Core.Tests/GitRepositoryTests.cs
@@ -116,7 +116,7 @@
                     // Advance remote
                     fixture.Repository.Checkout("develop");
                     var advancedCommit = fixture.Repository.MakeACommit();
-                    Commands.Fetch((Repository)localFixture.Repository, localFixture.Repository.Network.Remotes["origin"].Name, null, null, null);
+                    Commands.Fetch((Repository)localFixture.Repository, localFixture.Repository.Network.Remotes["origin"].Name, new string[0], null, null);
                     localFixture.Repository.Checkout(advancedCommit.Sha);
                     GitRepositoryHelper.NormalizeGitDirectory(localFixture.RepositoryPath, new AuthenticationInfo(), noFetch: false, currentBranch: "ref/heads/develop");
 

--- a/src/GitTools.Core.Tests/GitRepositoryTests.cs
+++ b/src/GitTools.Core.Tests/GitRepositoryTests.cs
@@ -116,7 +116,7 @@
                     // Advance remote
                     fixture.Repository.Checkout("develop");
                     var advancedCommit = fixture.Repository.MakeACommit();
-                    localFixture.Repository.Network.Fetch(localFixture.Repository.Network.Remotes["origin"]);
+                    Commands.Fetch((Repository)localFixture.Repository, localFixture.Repository.Network.Remotes["origin"].Name, null, null, null);
                     localFixture.Repository.Checkout(advancedCommit.Sha);
                     GitRepositoryHelper.NormalizeGitDirectory(localFixture.RepositoryPath, new AuthenticationInfo(), noFetch: false, currentBranch: "ref/heads/develop");
 

--- a/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
+++ b/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,8 +46,8 @@
       <HintPath>..\packages\GitTools.Testing.1.1.0\lib\net4\GitTools.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20150419160303\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
@@ -86,6 +86,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
@@ -94,7 +95,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
+++ b/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.7.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">

--- a/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
+++ b/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
@@ -25,7 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591,1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/GitTools.Core.Tests/GlobalInitialization.cs
+++ b/src/GitTools.Core.Tests/GlobalInitialization.cs
@@ -3,7 +3,7 @@
 [SetUpFixture]
 public class GlobalInitialization
 {
-    [SetUp]
+    [OneTimeSetUp]
     public static void SetUp()
     {
 #if DEBUG

--- a/src/GitTools.Core.Tests/app.config
+++ b/src/GitTools.Core.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="LibGit2Sharp" publicKeyToken="7cbde695407f0333" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.23.0.0" newVersion="0.23.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/GitTools.Core.Tests/packages.config
+++ b/src/GitTools.Core.Tests/packages.config
@@ -4,6 +4,6 @@
   <package id="GitTools.Testing" version="1.1.0" targetFramework="net45" />
   <package id="LibGit2Sharp" version="0.22.0" targetFramework="net45" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="Shouldly" version="2.7.0" targetFramework="net45" />
 </packages>

--- a/src/GitTools.Core.Tests/packages.config
+++ b/src/GitTools.Core.Tests/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Atlassian.SDK" version="2.5.0" targetFramework="net45" />
   <package id="GitTools.Testing" version="1.1.0" targetFramework="net45" />
-  <package id="LibGit2Sharp" version="0.22.0" targetFramework="net45" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net45" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="Shouldly" version="2.7.0" targetFramework="net45" />
 </packages>

--- a/src/GitTools.Core.sln
+++ b/src/GitTools.Core.sln
@@ -1,10 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".misc", ".misc", "{72ECAB81-A674-4AC8-8795-7AD71C3E1A5A}"
 	ProjectSection(SolutionItems) = preProject
+		..\.travis.yml = ..\.travis.yml
 		..\appveyor.yml = ..\appveyor.yml
 		GitTools.Core.sln.DotSettings = GitTools.Core.sln.DotSettings
 		..\GitVersionConfig.yaml = ..\GitVersionConfig.yaml

--- a/src/GitTools.Core.sln.DotSettings
+++ b/src/GitTools.Core.sln.DotSettings
@@ -448,6 +448,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=NUnit2x/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/UserInterface/ShortcutSchemeName/@EntryValue">None</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>

--- a/src/GitTools.Core.sln.DotSettings
+++ b/src/GitTools.Core.sln.DotSettings
@@ -406,6 +406,8 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 </s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/LayoutType/@EntryValue">CustomLayout</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderRegionName/@EntryValue"></s:String>
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue"></s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FF/@EntryIndexedValue">FF</s:String>
 	
 	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FCONSTRUCTOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>

--- a/src/GitTools.Core/GitTools.Core.NET40/GitTools.Core.NET40.csproj
+++ b/src/GitTools.Core/GitTools.Core.NET40/GitTools.Core.NET40.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,8 +41,8 @@
     <DocumentationFile>..\..\..\output\Release\GitTools.Core\net4\GitTools.Core.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\LibGit2Sharp.0.23.0-pre20150419160303\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -70,7 +70,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/GitTools.Core/GitTools.Core.NET40/GitTools.Core.NET40.csproj
+++ b/src/GitTools.Core/GitTools.Core.NET40/GitTools.Core.NET40.csproj
@@ -27,7 +27,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\..\output\Debug\GitTools.Core\net4\GitTools.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591,414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/GitTools.Core/GitTools.Core.NET40/packages.config
+++ b/src/GitTools.Core/GitTools.Core.NET40/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp" version="0.22.0" targetFramework="net40" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net40" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net40" />
   <package id="LibLog" version="4.2.5" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/src/GitTools.Core/GitTools.Core.NET45/GitTools.Core.NET45.csproj
+++ b/src/GitTools.Core/GitTools.Core.NET45/GitTools.Core.NET45.csproj
@@ -26,7 +26,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\..\output\Debug\GitTools.Core\net45\GitTools.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591,414</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/GitTools.Core/GitTools.Core.NET45/GitTools.Core.NET45.csproj
+++ b/src/GitTools.Core/GitTools.Core.NET45/GitTools.Core.NET45.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,8 +40,8 @@
     <DocumentationFile>..\..\..\output\Release\GitTools.Core\net45\GitTools.Core.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\LibGit2Sharp.0.23.0-pre20150419160303\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -69,7 +69,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/GitTools.Core/GitTools.Core.NET45/packages.config
+++ b/src/GitTools.Core/GitTools.Core.NET45/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp" version="0.22.0" targetFramework="net45" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net45" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net45" />
   <package id="LibLog" version="4.2.5" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/GitTools.Core/GitTools.Core.Shared/Git/Extensions/LibGitExtensions.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/Git/Extensions/LibGitExtensions.cs
@@ -33,7 +33,7 @@
 
         static bool IsSameBranch(Branch branch, Branch b)
         {
-            return (b.IsRemote ? b.FriendlyName.Replace(b.Remote.Name + "/", string.Empty) : b.FriendlyName) != branch.FriendlyName;
+            return (b.IsRemote ? b.FriendlyName.Replace(b.RemoteName + "/", string.Empty) : b.FriendlyName) != branch.FriendlyName;
         }
 
         public static IEnumerable<Branch> GetBranchesContainingCommit([NotNull] this Commit commit, IRepository repository, IList<Branch> branches, bool onlyTrackedBranches)

--- a/src/GitTools.Core/GitTools.Core.Shared/Git/Extensions/LibGitExtensions.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/Git/Extensions/LibGitExtensions.cs
@@ -99,12 +99,12 @@
         {
             var gitDirectory = repository.Info.Path;
 
-            gitDirectory = gitDirectory.TrimEnd('\\');
+            gitDirectory = gitDirectory.TrimEnd(Path.DirectorySeparatorChar);
 
             if (omitGitPostFix && gitDirectory.EndsWith(".git"))
             {
                 gitDirectory = gitDirectory.Substring(0, gitDirectory.Length - ".git".Length);
-                gitDirectory = gitDirectory.TrimEnd('\\');
+                gitDirectory = gitDirectory.TrimEnd(Path.DirectorySeparatorChar);
             }
 
             return gitDirectory;

--- a/src/GitTools.Core/GitTools.Core.Shared/Git/Helpers/GitRepositoryHelper.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/Git/Helpers/GitRepositoryHelper.cs
@@ -36,7 +36,7 @@
                     Log.Info(string.Format("Fetching from remote '{0}' using the following refspecs: {1}.",
                         remote.Name, string.Join(", ", remote.FetchRefSpecs.Select(r => r.Specification))));
                     var fetchOptions = BuildFetchOptions(authentication.Username, authentication.Password);
-                    repo.Network.Fetch(remote, fetchOptions);
+                    Commands.Fetch(repo, remote.Name, null, fetchOptions, null);
                 }
 
                 EnsureLocalBranchExistsForCurrentBranch(repo, currentBranch);
@@ -143,8 +143,8 @@
             var allBranchesFetchRefSpec = string.Format("+refs/heads/*:refs/remotes/{0}/*", remote.Name);
 
             Log.Info(string.Format("Adding refspec: {0}", allBranchesFetchRefSpec));
-
-            repo.Network.Remotes.Update(remote,
+            
+            repo.Network.Remotes.Update(remote.Name,
                 r => r.FetchRefSpecs.Add(allBranchesFetchRefSpec));
         }
 

--- a/src/GitTools.Core/GitTools.Core.Shared/Git/Helpers/GitRepositoryHelper.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/Git/Helpers/GitRepositoryHelper.cs
@@ -36,7 +36,7 @@
                     Log.Info(string.Format("Fetching from remote '{0}' using the following refspecs: {1}.",
                         remote.Name, string.Join(", ", remote.FetchRefSpecs.Select(r => r.Specification))));
                     var fetchOptions = BuildFetchOptions(authentication.Username, authentication.Password);
-                    Commands.Fetch(repo, remote.Name, null, fetchOptions, null);
+                    Commands.Fetch(repo, remote.Name, new string[0], fetchOptions, null);
                 }
 
                 EnsureLocalBranchExistsForCurrentBranch(repo, currentBranch);

--- a/src/GitTools.Core/GitTools.Core.Shared/Helpers/ProcessHelper.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/Helpers/ProcessHelper.cs
@@ -132,14 +132,32 @@ namespace GitTools
 
         public struct ChangeErrorMode : IDisposable
         {
-            int oldMode;
+            readonly int oldMode;
 
             public ChangeErrorMode(ErrorModes mode)
             {
-                oldMode = SetErrorMode((int)mode);
+                try
+                {
+                    oldMode = SetErrorMode((int)mode);
+                }
+                catch (EntryPointNotFoundException)
+                {
+                    oldMode = (int)mode;
+                }
             }
 
-            void IDisposable.Dispose() { SetErrorMode(oldMode); }
+
+            void IDisposable.Dispose()
+            {
+                try
+                {
+                    SetErrorMode(oldMode);
+                }
+                catch (EntryPointNotFoundException)
+                {
+                    // NOTE: Mono doesn't support DllImport("kernel32.dll") and its SetErrorMode method, obviously. @asbjornu
+                }
+            }
 
             [DllImport("kernel32.dll")]
             static extern int SetErrorMode(int newMode);

--- a/src/GitTools.Core/GitTools.Core.Shared/IO/Helpers/DeleteHelper.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/IO/Helpers/DeleteHelper.cs
@@ -1,5 +1,6 @@
 ﻿namespace GitTools.IO
 {
+    using System;
     using System.IO;
 
     public static class DeleteHelper
@@ -27,11 +28,17 @@
                     catch (FileNotFoundException)
                     {
                     }
+                    catch (UnauthorizedAccessException)
+                    {
+                    }
                 }
 
                 Directory.Delete(directory, true);
             }
             catch (DirectoryNotFoundException)
+            {
+            }
+            catch (UnauthorizedAccessException)
             {
             }
         }
@@ -44,6 +51,9 @@
                 Directory.Delete(directory, recursive);
             }
             catch (DirectoryNotFoundException)
+            {
+            }
+            catch (UnauthorizedAccessException)
             {
             }
         }

--- a/src/GitTools.Core/GitTools.Core.Shared/IO/Helpers/DeleteHelper.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/IO/Helpers/DeleteHelper.cs
@@ -11,17 +11,41 @@
                 return;
             }
 
-            foreach (var fileName in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
+            try
             {
-                var fileInfo = new FileInfo(fileName)
+                foreach (var fileName in Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories))
                 {
-                    IsReadOnly = false
-                };
+                    var fileInfo = new FileInfo(fileName)
+                    {
+                        IsReadOnly = false
+                    };
 
-                fileInfo.Delete();
+                    try
+                    {
+                        fileInfo.Delete();
+                    }
+                    catch (FileNotFoundException)
+                    {
+                    }
+                }
+
+                Directory.Delete(directory, true);
             }
+            catch (DirectoryNotFoundException)
+            {
+            }
+        }
 
-            Directory.Delete(directory, true);
+
+        public static void DeleteDirectory(string directory, bool recursive)
+        {
+            try
+            {
+                Directory.Delete(directory, recursive);
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## TODO

- [ ] Merge and pre-release GitTools/GitTools.Testing#2 on NuGet.
- [ ] Update to the above pre-release of GitTools.Testing.
- [x] Fix the [tests now failing](https://travis-ci.org/asbjornu/GitTools.Core#L2423) with `System.ArgumentNullException : Value cannot be null. Parameter name: source at System.Linq.Enumerable.ToArray[TSource] (IEnumerable`1 source)`
- [x] Fix [IO related failing tests](https://travis-ci.org/asbjornu/GitTools.Core/builds/124407128#L2412).
- [ ] Fix the [tests asserting the wrong temporary path](https://travis-ci.org/asbjornu/GitTools.Core/builds/124417372#L2425).
- [x] Fix [tests failing with `EntryPointNotFoundException` due to `SetErrorMode()` not being supported on Mono](https://travis-ci.org/asbjornu/GitTools.Core/builds/124417372#L2413).

## Overview

This PR adds a Travis build to ensure Linux/Mono compatibility and upgrades `LibGit2Sharp` to [version `0.23.0-pre20150419160303`](https://www.nuget.org/packages/LibGit2Sharp/0.23.0-pre20150419160303) so we get the fixes in libgit2/libgit2sharp#1298.

### GitTools.Testing

This PR depends on GitTools/GitTools.Testing#2 needs to be merged and released on NuGet, so that dependency can be updated.

When all of the above is figured out and fixed, it would be nice to have this merged and pre-released on NuGet, so I can go on to update GitVersion as well.
