### PR TITLE
Fix checkout bug in GitRepositoryHelper

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 install:
   - choco install gitversion.portable -pre -y
-  - cinst gitlink -pre -y
+  - cinst gitlink -y
   
 platform:
   - Any CPU

--- a/src/GitTools.Core/GitTools.Core.Shared/Git/Helpers/GitRepositoryHelper.cs
+++ b/src/GitTools.Core/GitTools.Core.Shared/Git/Helpers/GitRepositoryHelper.cs
@@ -139,7 +139,17 @@ Please run `git {0}` and submit it along with your build log (with personal info
             var isRef = currentBranch.Contains("refs");
             var isBranch = currentBranch.Contains("refs/heads");
             var localCanonicalName = !isRef ? "refs/heads/" + currentBranch : isBranch ? currentBranch : currentBranch.Replace("refs/", "refs/heads/");
+
             var repoTip = repo.Head.Tip;
+            
+            // We currently have the rep.Head of the *default* branch, now we need to look up the right one
+            var originCanonicalName = string.Format("origin/{0}", currentBranch);
+            var originBranch = repo.Branches[originCanonicalName];
+            if (originBranch != null)
+            {
+                repoTip = originBranch.Tip;
+            }
+
             var repoTipId = repoTip.Id;
 
             if (repo.Branches.All(b => b.CanonicalName != localCanonicalName))


### PR DESCRIPTION
When a specific branch is specified in GitRepositoryHelper, it should not checkout the *default branch* of the repository with the specified branch name, but it should checkout the actual remote branch