### PR TITLE
GitTools.Core --> dropped libgit2sharp.portable dependency.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,10 @@ before_build:
 
 build_script:
 # Need to fetch unshallow otherwise gitlink can't find commits.
-  - cmd: git fetch --unshallow
   - cmd: msbuild %path_to_sln% /t:Build /p:Configuration=Release /p:Platform="Any CPU"
 
 after_build:
-  - cmd: gitlink . -u https://github.com/gittools/gittools.core -b %APPVEYOR_REPO_BRANCH% -s %APPVEYOR_REPO_COMMIT% -f %path_to_sln%
+  - cmd: IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" gitlink . -u https://github.com/gittools/gittools.core -b %APPVEYOR_REPO_BRANCH% -s %APPVEYOR_REPO_COMMIT% -f %path_to_sln%
   - cmd: msbuild %path_to_sln% /t:Pack /p:PackageVersion=%GitVersion_NuGetVersion% /p:PackageOutputPath="%APPVEYOR_BUILD_FOLDER%"
   - cmd: appveyor PushArtifact "GitTools.Core.%GitVersion_NuGetVersion%.nupkg"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,8 @@ before_build:
   - cmd: msbuild %path_to_sln% /t:restore /p:PackageVersion=%GitVersion_NuGetVersion% /p:Configuration=Release /p:Platform="Any CPU"
 
 build_script:
+# Need to convert from shallow to complete for Pkg.clone to work  
+  - cmd: IF EXIST .git\shallow (git fetch --unshallow) 
   - cmd: msbuild %path_to_sln% /t:Build /p:Configuration=Release /p:Platform="Any CPU"
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ before_build:
   - cmd: msbuild %path_to_sln% /t:restore /p:PackageVersion=%GitVersion_NuGetVersion% /p:Configuration=Release /p:Platform="Any CPU"
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work  
-  - cmd: IF EXIST .git\shallow (git fetch --unshallow) 
+# Need to fetch unshallow otherwise gitlink can't find commits.
+  - cmd: git fetch --unshallow
   - cmd: msbuild %path_to_sln% /t:Build /p:Configuration=Release /p:Platform="Any CPU"
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,6 @@ before_build:
   - cmd: msbuild %path_to_sln% /t:restore /p:PackageVersion=%GitVersion_NuGetVersion% /p:Configuration=Release /p:Platform="Any CPU"
 
 build_script:
-# Need to fetch unshallow otherwise gitlink can't find commits.
   - cmd: msbuild %path_to_sln% /t:Build /p:Configuration=Release /p:Platform="Any CPU"
 
 after_build:

--- a/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
+++ b/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   
   <ItemGroup>  
-    <PackageReference Include="Dazinator.GitTools.Testing.Netstandard" Version="1.1.1-beta0001temp" />
+    <PackageReference Include="GitTools.Testing" Version="1.2.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />

--- a/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
+++ b/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
@@ -2,12 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">  
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">Any CPU</Platform>
-   
+    <Platform Condition=" '$(Platform)' == '' ">Any CPU</Platform>   
     <OutputType>Library</OutputType>
     <TargetFramework>net46</TargetFramework>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
-    <!--<TargetFramework>netcoreapp1.1;net46</TargetFramework>-->
+    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>  
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,9 +35,7 @@
   
   <ItemGroup Condition=" '$(Configuration)' == 'net46' ">
     <PackageReference Include="Atlassian.SDK" Version="2.5.0" />      
-  </ItemGroup>
-
- 
+  </ItemGroup> 
  
   <ItemGroup>
     <ProjectReference Include="..\GitTools.Core\GitTools.Core.csproj" />      
@@ -47,17 +43,6 @@
   
   <ItemGroup>
     <Folder Include="Properties\" />
-  </ItemGroup> 
-  
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup> 
+  </ItemGroup>   
  
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/GitTools.Core/GitTools.Core.csproj
+++ b/src/GitTools.Core/GitTools.Core.csproj
@@ -31,16 +31,8 @@
     <DefineConstants>TRACE;LIBLOG_PORTABLE;NETSTANDARD1_3;</DefineConstants>
   </PropertyGroup>
 
-  <!--<PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
-    <DefineConstants>${DefineConstants}net452;</DefineConstants>
-  </PropertyGroup>-->
-
-  <!--<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;LIBLOG_PORTABLE;NETSTANDARD1_3;</DefineConstants>
-  </PropertyGroup>-->
-
   <ItemGroup>
-
+    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
@@ -53,13 +45,12 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
 
-    <PackageReference Include="LibGit2Sharp" Version="0.24.0" />
+  
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
 
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="LibGit2Sharp" Version="0.24.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">   
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
@@ -69,12 +60,13 @@
   <!-- TODO: Unify this dependency with the LibGit2Sharp NuGet dependency
     when the portable NuGet has been officially released. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="LibGit2Sharp.Portable" Version="0.24.10" />
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />    
   </ItemGroup>
+
+ 
 
 </Project>

--- a/src/GitTools.Core/GitTools.Core.csproj
+++ b/src/GitTools.Core/GitTools.Core.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <!--<TargetFramework>netstandard1.3</TargetFramework>-->
     <OutputType>Library</OutputType>
@@ -16,9 +15,7 @@
     <Copyright>Copyright GitTools 2015.</Copyright>
     <PackageLicenseUrl>https://github.com/GitTools/GitTools.Core/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://raw.github.com/GitTools/GitTools.Core/master/GitTools_logo.png</PackageIconUrl>
-
   </PropertyGroup>
-
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <DefineConstants>TRACE;NET45;NETDESKTOP</DefineConstants>
@@ -26,7 +23,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
     <DefineConstants>TRACE;NET40;NETDESKTOP</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>TRACE;LIBLOG_PORTABLE;NETSTANDARD1_3;</DefineConstants>
   </PropertyGroup>
@@ -36,18 +32,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-
-  
+    <Reference Include="System.Xml" />  
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
-
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">   
@@ -56,17 +48,12 @@
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
-
-  <!-- TODO: Unify this dependency with the LibGit2Sharp NuGet dependency
-    when the portable NuGet has been officially released. -->
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />    
-  </ItemGroup>
-
- 
-
+  </ItemGroup> 
 </Project>

--- a/src/GitTools.Core/GitTools.Core.nuspec
+++ b/src/GitTools.Core/GitTools.Core.nuspec
@@ -15,7 +15,7 @@
     <licenseUrl>https://github.com/GitTools/GitTools.Core/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://raw.github.com/GitTools/GitTools.Core/master/GitTools_logo.png</iconUrl>
     <dependencies>
-      <dependency id="LibGit2Sharp" version="0.24.0" />
+      <dependency id="LibGit2Sharp" version="0.25.0-preview-0033" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
LibGit2Sharp.Portable isn't needed anymore. Should use latest libgit2sharp package instead.

GitTools.Core.Tests --> Can do the same for that project once following PR is merged: https://github.com/GitTools/GitTools.Testing/pull/13