### PR TITLE
Upgrade LibGit2Sharp to 0.26.0-preview-0070

### DIFF
--- a/src/GitTools.Core.Tests/Git/DynamicRepositoriesTests.cs
+++ b/src/GitTools.Core.Tests/Git/DynamicRepositoriesTests.cs
@@ -32,7 +32,7 @@
             {
                 using (var fixture = new EmptyRepositoryFixture())
                 {
-                    var expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split(Path.DirectorySeparatorChar).Last());
+                    var expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).Last());
 
                     fixture.Repository.MakeCommits(5);
                     fixture.Repository.CreateFileAndCommit("TestFile.txt");
@@ -50,7 +50,7 @@
                     using (var dynamicRepository = DynamicRepositories.CreateOrOpen(repositoryInfo, tempPath, branchName, branch.Tip.Sha))
                     {
                         dynamicRepositoryPath = dynamicRepository.Repository.Info.Path;
-                        dynamicRepository.Repository.Info.Path.ShouldBe(Path.Combine(expectedDynamicRepoLocation, ".git\\"));
+                        dynamicRepository.Repository.Info.Path.ShouldBe(Path.Combine(expectedDynamicRepoLocation, ".git" + Path.DirectorySeparatorChar));
 
                         var currentBranch = dynamicRepository.Repository.Head.CanonicalName;
 
@@ -130,7 +130,7 @@
                 {
                     var head = fixture.Repository.CreateFileAndCommit("TestFile.txt");
                     File.Copy(Path.Combine(fixture.RepositoryPath, "TestFile.txt"), Path.Combine(tempDir, "TestFile.txt"));
-                    expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split(Path.DirectorySeparatorChar).Last());
+                    expectedDynamicRepoLocation = Path.Combine(tempPath, fixture.RepositoryPath.Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).Last());
                     Directory.CreateDirectory(expectedDynamicRepoLocation);
 
                     var repositoryInfo = new RepositoryInfo
@@ -140,7 +140,7 @@
 
                     using (var dynamicRepository = DynamicRepositories.CreateOrOpen(repositoryInfo, tempPath, "master", head.Sha))
                     {
-                        dynamicRepository.Repository.Info.Path.ShouldBe(Path.Combine(expectedDynamicRepoLocation + "_1", ".git\\"));
+                        dynamicRepository.Repository.Info.Path.ShouldBe(Path.Combine(expectedDynamicRepoLocation + "_1", ".git" + Path.DirectorySeparatorChar));
                     }
                 }
             }

--- a/src/GitTools.Core.Tests/Git/GitRepositoryHelperTests.cs
+++ b/src/GitTools.Core.Tests/Git/GitRepositoryHelperTests.cs
@@ -220,7 +220,7 @@
                 // fixture.AssertFullSemver("2.0.0");
                 fixture.MakeACommit();
 
-#if !NETCOREAPP1_1
+#if !NETCOREAPP2_0
                 fixture.Repository.DumpGraph();
 #endif
                 // fixture.AssertFullSemver("2.0.1+1");

--- a/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
+++ b/src/GitTools.Core.Tests/GitTools.Core.Tests.csproj
@@ -1,26 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">  
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">Any CPU</Platform>   
+    <Platform Condition=" '$(Platform)' == '' ">Any CPU</Platform>
     <OutputType>Library</OutputType>
-    <TargetFramework>net46</TargetFramework>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>  
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>   
+    <DebugType>full</DebugType>
     <OutputPath>..\..\output\debug\GitTools.Core.Tests\$(TargetFramework)\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>  
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\output\release\GitTools.Core.Tests\$(TargetFramework)\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>   
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
-  
-  <ItemGroup>  
+
+  <ItemGroup>
     <PackageReference Include="GitTools.Testing" Version="1.2.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" />
@@ -29,20 +28,20 @@
     <PackageReference Include="Shouldly" Version="2.8.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(Configuration)' == 'netcoreapp1.1' ">
-    <PackageReference Include="Atlassian.SDK" Version="9.5.0" />    
+  <ItemGroup Condition=" '$(Configuration)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Atlassian.SDK" Version="9.5.0" />
   </ItemGroup>
-  
-  <ItemGroup Condition=" '$(Configuration)' == 'net46' ">
-    <PackageReference Include="Atlassian.SDK" Version="2.5.0" />      
-  </ItemGroup> 
- 
+
+  <ItemGroup Condition=" '$(Configuration)' == 'net461' ">
+    <PackageReference Include="Atlassian.SDK" Version="2.5.0" />
+  </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\GitTools.Core\GitTools.Core.csproj" />      
-  </ItemGroup> 
-  
+    <ProjectReference Include="..\GitTools.Core\GitTools.Core.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="Properties\" />
-  </ItemGroup>   
- 
+  </ItemGroup>
+
 </Project>

--- a/src/GitTools.Core/Git/DynamicRepositories.cs
+++ b/src/GitTools.Core/Git/DynamicRepositories.cs
@@ -70,7 +70,7 @@
 
         static string GetAndLockTemporaryRepositoryPath(string targetUrl, string dynamicRepositoryLocation)
         {
-            var repositoryName = targetUrl.Split('/', '\\').Last().Replace(".git", string.Empty);
+            var repositoryName = targetUrl.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries).Last().Replace(".git", string.Empty);
             var possiblePath = Path.Combine(dynamicRepositoryLocation, repositoryName);
 
             var i = 1;

--- a/src/GitTools.Core/Git/Extensions/LibGitExtensions.cs
+++ b/src/GitTools.Core/Git/Extensions/LibGitExtensions.cs
@@ -150,7 +150,7 @@
             }
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD2_0
         public static void DumpGraph(this IRepository repository, Action<string> writer = null, int? maxCommits = null)
         {
             DumpGraph(repository.Info.Path, writer, maxCommits);

--- a/src/GitTools.Core/GitTools.Core.csproj
+++ b/src/GitTools.Core/GitTools.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!--<TargetFramework>netstandard1.3</TargetFramework>-->
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard1.3;net45;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 
     <!--Start of Nuspec metadata-->
     <PackageId>GitTools.Core</PackageId>
@@ -17,43 +17,29 @@
     <PackageIconUrl>https://raw.github.com/GitTools/GitTools.Core/master/GitTools_logo.png</PackageIconUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
-    <DefineConstants>TRACE;NET45;NETDESKTOP</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+    <DefineConstants>TRACE;NET461;NETDESKTOP</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
-    <DefineConstants>TRACE;NET40;NETDESKTOP</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <DefineConstants>TRACE;LIBLOG_PORTABLE;NETSTANDARD1_3;</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>TRACE;LIBLOG_PORTABLE;NETSTANDARD2_0;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0070" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />  
-    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">   
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />    
-  </ItemGroup> 
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+  </ItemGroup>
 </Project>

--- a/src/GitTools.Core/GitTools.Core.nuspec
+++ b/src/GitTools.Core/GitTools.Core.nuspec
@@ -19,11 +19,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="net4\GitTools.Core.dll" target="lib\net4\" />
-    <file src="net4\GitTools.Core.pdb" target="lib\net4\" />
-    <file src="net4\GitTools.Core.xml" target="lib\net4\" />
-    <file src="net45\GitTools.Core.dll" target="lib\net45\" />
-    <file src="net45\GitTools.Core.pdb" target="lib\net45\" />
-    <file src="net45\GitTools.Core.xml" target="lib\net45\" />
+    <file src="net461\GitTools.Core.dll" target="lib\net461\" />
+    <file src="net461\GitTools.Core.pdb" target="lib\net461\" />
+    <file src="net461\GitTools.Core.xml" target="lib\net461\" />
   </files>
 </package>

--- a/src/GitTools.Core/Helpers/ProcessHelper.cs
+++ b/src/GitTools.Core/Helpers/ProcessHelper.cs
@@ -1,6 +1,6 @@
-#if !NETSTANDARD1_3
+#if !NETSTANDARD2_0
 namespace GitTools
-{  
+{
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
@@ -8,7 +8,7 @@ namespace GitTools
     using System.IO;
     using System.Runtime.InteropServices;
     using System.Threading;
-    
+
 
     public static class ProcessHelper
     {


### PR DESCRIPTION
Part of fix for GitTools/GitVersion#1483 and GitTools/GitVersion#1511. Not strictly necessary, but would require adding a direct dependency from GitTools/GitVersion to libgit2/libgit2sharp.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Upgrade LibGit2Sharp from version 0.25.0-preview-0033 to 0.26.0-preview-0070.
- Remove target `net40` and retarget `net45` to `net461` since LibGit2Sharp now targets these frameworks.
- Retarget `netstandard1.3` to `netstandard2.0` since LibGit2Sharp now targets this framework.
- Fix `src/GitTools.Core/Git/DynamicRepositories.cs` so that it handles a trailing directory separator.
- Fix tests in `src/GitTools.Core.Tests/Git/DynamicRepositoriesTests.cs` so that it handles trailing directory separators and runs green under linux.